### PR TITLE
Stone Heads Adjacency in Modern

### DIFF
--- a/Community BugFix Mod.modinfo
+++ b/Community BugFix Mod.modinfo
@@ -98,6 +98,7 @@
 					<Item>xml/invis.xml</Item> 
 					<Item>xml/onsen.xml</Item> 
 					<Item>xml/renaissance.xml</Item>
+					<Item>xml/stone_heads.xml</Item>
         		</UpdateDatabase>
 				<UpdateText>
 					<Item>xml/goisshin_text.xml</Item> 

--- a/xml/stone_heads.xml
+++ b/xml/stone_heads.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Database>
+	<Adjacency_YieldChanges>
+		<Row ID="StoneheadCulture" AdjacentConstructible="IMPROVEMENT_STONE_HEAD" YieldChange="1.0" YieldType="YIELD_CULTURE"/>
+	</Adjacency_YieldChanges>
+	<Constructible_Adjacencies>
+		<Row ConstructibleType="IMPROVEMENT_STONE_HEAD" YieldChangeId="StoneheadCulture"/>
+	</Constructible_Adjacencies>
+</Database>


### PR DESCRIPTION
Stone heads from Exploration were losing adjacency from other Stone Heads in Modern. This could be considered an opinionated fix, I would not mind if it was rejected