### PR TITLE
Machu Pichu and Brihadswareer Temple adjacencies no longer lost in Modern

### DIFF
--- a/Community BugFix Mod.modinfo
+++ b/Community BugFix Mod.modinfo
@@ -98,6 +98,7 @@
 					<Item>xml/invis.xml</Item> 
 					<Item>xml/onsen.xml</Item> 
 					<Item>xml/renaissance.xml</Item>
+					<Item>xml/brihad_pikchu.xml</Item>
         		</UpdateDatabase>
 				<UpdateText>
 					<Item>xml/goisshin_text.xml</Item> 

--- a/xml/brihad_pikchu.xml
+++ b/xml/brihad_pikchu.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Database>
+	<Adjacency_YieldChanges>
+		<Update>
+			<Set Age= ""/>
+			<Where ID="BrihadeeswararTempleWildcardNavigableHappiness" />
+		</Update>
+        <Update>
+			<Set Age= ""/>
+			<Where ID="MachuPikchuWildcardCulture" />
+		</Update>
+        <Update>
+			<Set Age= ""/>
+			<Where ID="MachuPikchuWildcardGold" />
+		</Update>
+	</Adjacency_YieldChanges>
+</Database>


### PR DESCRIPTION
Makchu Pikchu and Brihadswareer Temple were losing their adjacency bonuses for Modern buildings. This seems unintended, given their Ageless status