### PR TITLE
Shipbuilding II does not interact weirdly with naval units

### DIFF
--- a/Community BugFix Mod.modinfo
+++ b/Community BugFix Mod.modinfo
@@ -79,6 +79,7 @@
 					<Item>xml/monastery.xml</Item>
 					<Item>xml/hikoi.xml</Item>
 					<Item>xml/domesday.xml</Item>
+					<Item>xml/shipbuildingII.xml</Item>
         		</UpdateDatabase>
 				<UpdateText>
 				</UpdateText>

--- a/xml/shipbuildingII.xml
+++ b/xml/shipbuildingII.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Database>
+	<Modifiers>
+		<Update>
+			<Set SubjectRequirementSetId="MOD_SLTH_BUGFIX_ISNT_NAVY_REQS" />
+			<Where ModifierId="MOD_TECH_OCEAN_TRAVEL_EMBARKED"/>
+		</Update>
+	</Modifiers>
+	<Requirements>
+		<Row RequirementId="MOD_SLTH_BUGFIX_ISNT_NAVY" RequirementType="REQUIREMENT_UNIT_TAG_MATCHES" Inverse="true" />
+	</Requirements>
+	<RequirementArguments>
+		<Row RequirementId="MOD_SLTH_BUGFIX_ISNT_NAVY" Name="Tag" Value="UNIT_CLASS_NAVAL" />
+	</RequirementArguments>
+	<RequirementSetRequirements>
+		<Row RequirementSetId="MOD_SLTH_BUGFIX_ISNT_NAVY_REQS" RequirementId="MOD_SLTH_BUGFIX_ISNT_NAVY"/>
+	</RequirementSetRequirements>
+	<RequirementSets>
+		<Row RequirementSetId="MOD_SLTH_BUGFIX_ISNT_NAVY_REQS" RequirementSetType="REQUIREMENTSET_TEST_ALL"/>
+	</RequirementSets>
+</Database>


### PR DESCRIPTION
amends shipbuilding II in exploration so the embark bonus doesn't apply to naval units, as otherwise they lose the ability to pillage, and have reduced movement.