### PR TITLE
 Shawnee Skote Culture fix

### DIFF
--- a/Community BugFix Mod.modinfo
+++ b/Community BugFix Mod.modinfo
@@ -79,6 +79,7 @@
 					<Item>xml/monastery.xml</Item>
 					<Item>xml/hikoi.xml</Item>
 					<Item>xml/domesday.xml</Item>
+					<Item>xml/skote_culture_suzerain.xml</Item>
         		</UpdateDatabase>
 				<UpdateText>
 				</UpdateText>

--- a/xml/skote_culture_suzerain.xml
+++ b/xml/skote_culture_suzerain.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Database>
+	<DynamicModifiers>
+		<Update>
+			<Set CollectionType="COLLECTION_PLAYER_CONSTRUCTIBLES" />
+			<Where ModifierType="MOD_WYEHI_SIMEKOFI_MAWASKAWE_SKOTE_TYPE" />
+		</Update>
+	</DynamicModifiers>
+</Database>


### PR DESCRIPTION
The Shawnee Skote improvement should grant +1 culture per suzerained city state once you get the civic for it. Note: This is on a DLC civ, but because the statement is an UPDATE WHERE, it will not block anything without the Shawnee, so does not need criteria