### PR TITLE
Missionary incense and ottru

### DIFF
--- a/Community BugFix Mod.modinfo
+++ b/Community BugFix Mod.modinfo
@@ -77,6 +77,7 @@
 					<Item>xml/shipbuildingII.xml</Item>
 					<Item>xml/skote_culture_suzerain.xml</Item>
 					<Item>sql/missionary_incense.sql</Item>
+					<Item>sql/ottru_shipbuilding_II.sql</Item>
         		</UpdateDatabase>
 				<UpdateText>
 				</UpdateText>

--- a/Community BugFix Mod.modinfo
+++ b/Community BugFix Mod.modinfo
@@ -76,6 +76,7 @@
 					<Item>xml/leiomano.xml</Item>
 					<Item>xml/shipbuildingII.xml</Item>
 					<Item>xml/skote_culture_suzerain.xml</Item>
+					<Item>sql/missionary_incense.sql</Item>
         		</UpdateDatabase>
 				<UpdateText>
 				</UpdateText>

--- a/sql/missionary_incense.sql
+++ b/sql/missionary_incense.sql
@@ -1,0 +1,3 @@
+-- Fix missionaries incense production
+INSERT OR REPLACE INTO  ModifierArguments(ModifierId, Name, "Value") VALUES
+('MOD_INCENSE_CITY_MISSIONARY_PRODUCTION', 'Percent', '100');

--- a/sql/ottru_shipbuilding_II.sql
+++ b/sql/ottru_shipbuilding_II.sql
@@ -1,0 +1,2 @@
+-- fix ottru not having naval class type (needed for the shipbuilding fix)
+INSERT OR REPLACE INTO TypeTags(Type, Tag) VALUES ('UNIT_OTTRU', 'UNIT_CLASS_NAVAL');


### PR DESCRIPTION
Missionaries were not produced faster when Incense was in a city.
https://forums.civfanatics.com/threads/community-bugfix-mod.695898/post-16805728

Ottru were not excluded in our bugfix for Shipbuilding II, as they do not have the NAVAL tag. adds that

Done in SQL as these fixes exist already in my Community Bugfix Extended, and want to make sure it doesn't break, so using Replace INTO.

